### PR TITLE
Fix #22

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
 var Provider = class Provider {
-	constructor(name = '', icon = '../icons/other.png', url = '', selected = false) {
+	constructor(name = '', icon = 'icons/other.png', url = '', selected = false) {
 		this.name = name;
 		this.icon = icon;
 		this.url = url;
@@ -11,14 +11,14 @@ var Provider = class Provider {
 };
 
 const defaultProviders = [
-	new Provider('Google', '../icons/google.png', 'https://www.google.com/searchbyimage?image_url=%s', true),
-	new Provider('IQDB', '../icons/iqdb.png', 'https://iqdb.org/?url=%s'),
-	new Provider('TinEye', '../icons/tineye.png', 'https://www.tineye.com/search?url=%s'),
-	new Provider('Bing', '../icons/bing.png', 'https://www.bing.com/images/searchbyimage?FORM=IRSBIQ&cbir=sbi&imgurl=%s'),
-	new Provider('Yandex', '../icons/yandex.png', 'https://yandex.com/images/search?url=%s&rpt=imageview'),
-	new Provider('Яндекс', '../icons/yandexru.png', 'https://yandex.ru/images/search?url=%s&rpt=imageview'),
-	new Provider('Baidu', '../icons/baidu.png', 'https://image.baidu.com/n/pc_search?queryImageUrl=%s'),
-	new Provider('SauceNAO', '../icons/saucenao.png', 'https://saucenao.com/search.php?db=999&url=%s'),
+	new Provider('Google', 'icons/google.png', 'https://www.google.com/searchbyimage?image_url=%s', true),
+	new Provider('IQDB', 'icons/iqdb.png', 'https://iqdb.org/?url=%s'),
+	new Provider('TinEye', 'icons/tineye.png', 'https://www.tineye.com/search?url=%s'),
+	new Provider('Bing', 'icons/bing.png', 'https://www.bing.com/images/searchbyimage?FORM=IRSBIQ&cbir=sbi&imgurl=%s'),
+	new Provider('Yandex', 'icons/yandex.png', 'https://yandex.com/images/search?url=%s&rpt=imageview'),
+	new Provider('Яндекс', 'icons/yandexru.png', 'https://yandex.ru/images/search?url=%s&rpt=imageview'),
+	new Provider('Baidu', 'icons/baidu.png', 'https://image.baidu.com/n/pc_search?queryImageUrl=%s'),
+	new Provider('SauceNAO', 'icons/saucenao.png', 'https://saucenao.com/search.php?db=999&url=%s'),
 ];
 
 function getDefaultProvidersClone() {

--- a/options/options.js
+++ b/options/options.js
@@ -1,6 +1,7 @@
 const backgroundPage = chrome.extension.getBackgroundPage();
 const Provider = backgroundPage.Provider; // class Provider
 const msgTimeout = 1800;
+const extensionUUID = chrome.extension.getURL('');
 
 /** Utility Functions **/
 const $ = document.querySelector.bind(document);
@@ -105,7 +106,7 @@ function createSpIconElement(src) {
 	span.classList.add('sp-icon', 'input-group-addon');
 
 	const iconImg = new Image();
-	iconImg.src = src;
+	iconImg.src = chrome.extension.getURL(src);
 
 	span.appendChild(iconImg);
 
@@ -192,7 +193,7 @@ function createSpCheckboxElement(selected) {
 	return span;
 }
 
-function createSearchProviderElement(name = '', icon = '../icons/other.png', url = '', selected = false, edit = true) {
+function createSearchProviderElement(name = '', icon = 'icons/other.png', url = '', selected = false, edit = true) {
 	const root = $el('div');
 	root.classList.add('searchProviderListItem', 'input-group');
 
@@ -288,7 +289,7 @@ saveOptions.onclick = () => {
 	for (const li of searchProviderList.children) {
 		const index = Array.from(searchProviderList.children).indexOf(li) + 1;
 		const selected = li.children[0].firstElementChild.firstElementChild.checked;
-		const icon = li.children[1].firstElementChild.src;
+		const icon = li.children[1].firstElementChild.src.replace(extensionUUID, '');
 		const name = li.children[2].value;
 		const url = li.children[3].value;
 


### PR DESCRIPTION
I found this issue happens again when update extension. I guess the reason is Firefox update.

[Explanation from MDN](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/web_accessible_resources):
> This UUID is randomly generated for every browser instance and is not your extension's ID. This prevents websites from fingerprinting the extensions a user has installed.

Now you can use `about:debugging` to save options and icons will always correct.