### PR TITLE
Add an option to open all providers by default

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -15,6 +15,10 @@
 		"message": "Open in background"
 	},
 
+	"openAllByDefaultLabel": {
+		"message": "Open all by default"
+	},
+
 	"optionsPageTitle": {
 		"message": "Options"
 	},

--- a/background.js
+++ b/background.js
@@ -30,9 +30,10 @@ function createContextMenu(storedSettings) {
 	const title = chrome.i18n.getMessage('contextMenuTitle');
 
 	const selectedProviders = storedSettings.storageProviders.filter(p => p.selected);
+	const openAllByDefault = storedSettings.openAllByDefault;
 
 	/* If there is only one search provider, do not create a submenu */
-	if (selectedProviders.length === 1) {
+	if (selectedProviders.length === 1 || openAllByDefault) {
 		chrome.contextMenus.create({
 			id: selectedProviders[0].name,
 			title,
@@ -78,6 +79,7 @@ function createContextMenu(storedSettings) {
 /* Default settings. If there is nothing in storage, use these values. */
 const defaultSettings = {
 	openInBackground: false,
+	openAllByDefault: false,
 	openTabAt: 'right',
 	storageProviders: getDefaultProvidersClone(),
 };
@@ -116,7 +118,7 @@ function reverseSearch(info, storedSettings) {
 
 	/* return array of url string */
 	function getProviderURLs(targetProviderName) {
-		if (targetProviderName === 'openAll') {
+		if (targetProviderName === 'openAll' || storedSettings.openAllByDefault) {
 			const urls = [];
 			for (const p of storedSettings.storageProviders) {
 				if (p.selected) {

--- a/options/options.html
+++ b/options/options.html
@@ -29,6 +29,17 @@
 			</div>
 		</div>
 
+		<!-- "Open all by default" checkbox -->
+		<div class="form-group row">
+			<label for="openAllByDefault" class="col-sm-3" id="openAllByDefaultLabel">{{i18n.openAllByDefaultLabel}}</label>
+			<div class="col-sm-9">
+				<label class="form-check-label custom-control custom-checkbox">
+					<input class="form-check-input custom-control-input" type="checkbox" id="openAllByDefault" />
+					<span class="custom-control-indicator"></span>
+				</label>
+			</div>
+		</div>
+
 		<!-- "Open tab at" select dropdown -->
 		<div class="form-group row">
 			<label for="openTabAt" class="col-sm-3 col-form-label" id="openTabAtLabel">{{i18n.openTabAtLabel}}</label>

--- a/options/options.js
+++ b/options/options.js
@@ -260,6 +260,7 @@ document.title = `${chrome.i18n.getMessage('extensionName')} | ${chrome.i18n.get
 
 $('#navbarTitle').textContent = chrome.i18n.getMessage('extensionName');
 $('#openInBackgroundLabel').textContent = chrome.i18n.getMessage('openInBackgroundLabel');
+$('#openAllByDefaultLabel').textContent = chrome.i18n.getMessage('openAllByDefaultLabel');
 
 $('#openTabAtLabel').textContent = chrome.i18n.getMessage('openTabAtLabel');
 $('#openTabAtRight').textContent = chrome.i18n.getMessage('openTabAtRight');
@@ -299,6 +300,7 @@ saveOptions.onclick = () => {
 	const nameSet = new Set();
 	const storedSettings = {
 		openInBackground: $('#openInBackground').checked,
+		openAllByDefault: $('#openAllByDefault').checked,
 		openTabAt: $('#openTabAt')[$('#openTabAt').selectedIndex].value,
 		storageProviders: [],
 	};
@@ -361,6 +363,7 @@ function updateUI(storedSettings) {
 		.map(opt => opt.value)
 		.indexOf(storedSettings.openTabAt);
 	$('#openInBackground').checked = storedSettings.openInBackground;
+	$('#openAllByDefault').checked = storedSettings.openAllByDefault;
 
 	for (const p of storedSettings.storageProviders) {
 		$('#searchProviderList').appendChild(createSearchProviderElement(p.name, p.icon, p.url, p.selected, false));


### PR DESCRIPTION
Hi!

I love the simplicity of your add-on, I love the customizable providers, and I love the open-sourceness. 👍 

However, I was missing a basic feature that some other extensions have: the possibility to search all providers directly from the context menu, without having to go through a submenu.
This may seem like a detail, but it is much more pleasant when like me, we always launch a generalized search.

So I slightly modified the source code to add an option that, if checked, disables the submenu when there are multiple providers, and directly launch a search on each of them.

I tested it locally and it seems to work very well.

What do you think ?