### PR TITLE
Add support for optional argument openerTabId for tabs.create()

### DIFF
--- a/background.js
+++ b/background.js
@@ -141,12 +141,14 @@ function reverseSearch(info, storedSettings) {
 
 	function openImageSearch(tabs) {
 		const tabIndex = getTabIndex(openTabAt, tabs);
-
+		const thisTab = tabs.filter(t => t.active)[0];
+		
 		for (const p of searchProviders) {
 			chrome.tabs.create({
 				url: p.replace('%s', encodeURIComponent(imageURL)),
 				active: !openInBackground,
 				index: tabIndex,
+				openerTabId: thisTab.id,				
 			});
 		}
 	}


### PR DESCRIPTION
This change would simply add the openerTabId to the newly created tab.  This would allow addons like Tree Style Tab to track parent\children relationships and display them properly.  I have tested with the default arguments and it works with TST well.